### PR TITLE
Minor change on osparc integration

### DIFF
--- a/.osparc/Makefile
+++ b/.osparc/Makefile
@@ -4,8 +4,9 @@ SHELL := /bin/bash
 
 
 REPO_DIR := $(abspath $(CURDIR)/..)
-IMAGES=$(shell ./bin/yq.bash eval '.services.*.image' docker-compose.yml)
+IMAGES := $(shell ./bin/yq.bash eval '.services.*.image' docker-compose.yml)
 export DOCKER_REGISTRY ?= registry:5000
+
 
 .PHONY: info
 info: ## lists environments and required tools
@@ -15,7 +16,7 @@ info: ## lists environments and required tools
 	@echo 'docker buildx  : $(shell docker buildx version 2>/dev/null || echo WARNING optional tool missing )'
 	@echo 'make           : $(shell make --version 2>&1 | head -n 1)'
 	@echo 'awk            : $(shell awk -W version 2>&1 | head -n 1)'
-	# environs
+	# environments
 	@echo "REPO_DIR        = ${REPO_DIR}"
 	@echo "IMAGES          = ${IMAGES}"
 	@echo "DOCKER_REGISTRY = ${DOCKER_REGISTRY}"

--- a/.osparc/Makefile
+++ b/.osparc/Makefile
@@ -2,15 +2,23 @@
 .DEFAULT_GOAL := help
 SHELL := /bin/bash
 
+
 REPO_DIR := $(abspath $(CURDIR)/..)
-IMAGES=$(shell yq eval '.services.*.image' docker-compose.yml)
+IMAGES=$(shell ./bin/yq.bash eval '.services.*.image' docker-compose.yml)
 export DOCKER_REGISTRY ?= registry:5000
 
 .PHONY: info
-info: ## environs
-	@echo 'REPO_DIR =${REPO_DIR}'
-	@echo 'IMAGES   =${IMAGES}'
-	@echo 'DOCKER_REGISTRY =${DOCKER_REGISTRY}'
+info: ## lists environments and required tools
+	# tools
+	@echo 'docker         : $(shell docker --version 2>/dev/null || echo ERROR required tool missing )'
+	@echo 'docker compose : $(shell docker compose version 2>/dev/null || echo ERROR required tool missing )'
+	@echo 'docker buildx  : $(shell docker buildx version 2>/dev/null || echo WARNING optional tool missing )'
+	@echo 'make           : $(shell make --version 2>&1 | head -n 1)'
+	@echo 'awk            : $(shell awk -W version 2>&1 | head -n 1)'
+	# environs
+	@echo "REPO_DIR        = ${REPO_DIR}"
+	@echo "IMAGES          = ${IMAGES}"
+	@echo "DOCKER_REGISTRY = ${DOCKER_REGISTRY}"
 
 .PHONY: compose
 compose: ## creates docker-compose.yml

--- a/.osparc/Makefile
+++ b/.osparc/Makefile
@@ -4,7 +4,10 @@ SHELL := /bin/bash
 
 
 REPO_DIR := $(abspath $(CURDIR)/..)
-IMAGES := $(shell ./bin/yq.bash eval '.services.*.image' docker-compose.yml)
+
+# NOTE that IMAGES variable can change when docker-compose.yml gets rebuilt. Do NOT use := !!!
+IMAGES = $(shell ./bin/yq.bash eval '.services.*.image' docker-compose.yml)
+
 export DOCKER_REGISTRY ?= registry:5000
 
 

--- a/.osparc/Makefile
+++ b/.osparc/Makefile
@@ -23,17 +23,20 @@ info: ## lists environments and required tools
 
 .PHONY: compose
 compose: ## creates docker-compose.yml
+	# creating compose specs
 	cd $(REPO_DIR) \
 	&& .osparc/bin/ooil.bash compose -f .osparc/docker-compose.yml
 
 
 .PHONY: build build-nc
 build build-nc: compose ## builds image. Suffix -nc disables cache
+	# building
 	docker compose build $(if $(findstring -nc,$@),--no-cache,)
 
 
 .PHONY: push
 push: ## retags and pushes to ${DOCKER_REGISTRY}
+	# tag & push
 	@for image in ${IMAGES}; do \
 		echo "Tagging and pushing ${DOCKER_REGISTRY}/$$image ..."; \
 		docker tag "$$image" "${DOCKER_REGISTRY}/$$image"; \
@@ -41,6 +44,12 @@ push: ## retags and pushes to ${DOCKER_REGISTRY}
 	done
 	# registry view
 	@curl --silent ${DOCKER_REGISTRY}/v2/_catalog | jq
+
+
+
+.PHONY: all
+all: compose build-nc push ## all workflow
+	@echo "'${IMAGES}' built, and pushed to '${DOCKER_REGISTRY}'"
 
 
 .PHONY: help

--- a/.osparc/Makefile
+++ b/.osparc/Makefile
@@ -20,6 +20,7 @@ info: ## lists environments and required tools
 	@echo "IMAGES          = ${IMAGES}"
 	@echo "DOCKER_REGISTRY = ${DOCKER_REGISTRY}"
 
+
 .PHONY: compose
 compose: ## creates docker-compose.yml
 	cd $(REPO_DIR) \

--- a/.osparc/bin/yq.bash
+++ b/.osparc/bin/yq.bash
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Define variables
+YQ_IMAGE="mikefarah/yq"
+YQ_VERSION="4.12.0"
+
+# Define function to run yq inside container
+run_yq() {
+    docker run --rm -v "$(pwd):/workdir" "$YQ_IMAGE:$YQ_VERSION" "$@"
+}
+
+# Call function with arguments
+run_yq "$@"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # See https://pre-commit.com/hooks.html for more hooks
 exclude: "^.venv$|^.cache$|^.pytest_cache$"
-fail_fast: true
+fail_fast: false
 default_language_version:
   python: python3.10
 repos:


### PR DESCRIPTION
Improves``.osparc/Makefile`` recipes. To build & push into the osparc registry

- setup target registry (not this is a fake registry url) and check tools. This has to done **only once**
```cmd
cd .osparc
export DOCKER_REGISTRY=registry.osparc-master
make info
```
- build & push
```cmd
make all
```
